### PR TITLE
fix lint on Windows: force git to use LF

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,6 +14,10 @@ jobs:
         runs-on: ["ubuntu-latest", "windows-latest"]
     runs-on: ${{ matrix.runs-on }}
     steps:
+    - name: Force git to use LF
+      run: |
+        git config --global core.autocrlf false
+        git config --global core.eol lf
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
       with:


### PR DESCRIPTION
Found this hack on https://github.com/actions/checkout/issues/226